### PR TITLE
WIP: TWiB on Fountain

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 shows:
   this-week-in-bitcoin:
-    show_rss: https://serve.podhome.fm/rss/55b53584-4219-4fb0-b916-075ce23f714e
+    show_rss: https://feeds.jupiterbroadcasting.com/twib
     show_url: https://www.thisweekinbitcoin.show/
     jb_url: https://www.jupiterbroadcasting.com/show/this-week-in-bitcoin
     acronym: twib

--- a/models/channel.py
+++ b/models/channel.py
@@ -66,7 +66,7 @@ class Channel(ScraperBaseXmlModel, tag="channel"):
     link: str = element()
     generator: Optional[str] = element(default=None)
     language: str = element()
-    copyright: str = element()
+    copyright: Optional[str] = element(default=None)
     managingEditor: Optional[EmailStr] = element(default=None)
     lastBuildDate: Optional[str] = element(default=None)
     itunes_author: Optional[str] = Author
@@ -99,6 +99,17 @@ class Channel(ScraperBaseXmlModel, tag="channel"):
     podcast_value: Optional[Value] = None
     items: Tuple[Item, ...] = element(tag="item")
 
-    @field_validator("pubDate", mode="before")
+    @field_validator('pubDate', mode='before')
     def pubDate_validator(cls, value: str) -> str:
-        return datetime.strptime(value, "%a, %d %b %Y %H:%M:%S %z").isoformat()
+        formats = [
+            '%a, %d %b %Y %H:%M:%S %z',  # Numeric offset, e.g., +0000
+            '%a, %d %b %Y %H:%M:%S %Z',  # Abbreviation, e.g., GMT
+        ]
+        for fmt in formats:
+            try:
+                return datetime.strptime(value, fmt).isoformat()
+            except ValueError:
+                continue
+        raise ValueError(
+            f"pubDate '{value}' does not match supported formats."
+        )

--- a/models/episode.py
+++ b/models/episode.py
@@ -184,7 +184,7 @@ class Episode(BaseModel):
     # Path part of the URL to the episode page on show's Fireside website
     # Example:
     #   "/42"
-    fireside_url: str
+    fireside_url: Optional[str]
 
     value: Optional[Value]
 

--- a/models/item.py
+++ b/models/item.py
@@ -52,4 +52,15 @@ class Item(ScraperBaseXmlModel, tag='item'):
 
     @field_validator('pubDate', mode='before')
     def pubDate_validator(cls, value: str) -> str:
-        return datetime.strptime(value, '%a, %d %b %Y %H:%M:%S %z').isoformat()
+        formats = [
+            '%a, %d %b %Y %H:%M:%S %z',  # Numeric offset, e.g., +0000
+            '%a, %d %b %Y %H:%M:%S %Z',  # Abbreviation, e.g., GMT
+        ]
+        for fmt in formats:
+            try:
+                return datetime.strptime(value, fmt).isoformat()
+            except ValueError:
+                continue
+        raise ValueError(
+            f"pubDate '{value}' does not match supported formats."
+        )

--- a/scraper.py
+++ b/scraper.py
@@ -154,7 +154,8 @@ def parse_episode_number(title: str) -> str:
 
 def build_episode_file(item: Item, show: str, show_details: ShowDetails):
     episode_string = item.podcast_episode.episode if item.podcast_episode else parse_episode_number(item.title)
-    episode_number, episode_number_padded = (int(episode_string), f'{int(episode_string):04}') if episode_string.isnumeric() else tuple((item.link.split("/")[-1],))*2
+    import random
+    episode_number, episode_number_padded = (int(episode_string), f'{int(episode_string):04}') if episode_string.isnumeric() else (rn:=random.randint(1,100),f'{int(rn):04}') #tuple((item.link.split("/")[-1],))*2
 
     output_file = Path(Settings.DATA_DIR) / 'content' / 'show' / show / f'{episode_number_padded.replace("/","")}.md'
 
@@ -163,14 +164,14 @@ def build_episode_file(item: Item, show: str, show_details: ShowDetails):
         return
 
     try:
-        sponsors = parse_sponsors(item.link, episode_number,show,show_details)
+        sponsors = parse_sponsors(item.link, episode_number,show,show_details) if item.link else []
     except requests.HTTPError as e:
         logger.exception(
             f"Skipping {show_details.name} episode {episode_number} could not get episode page.\n"
             f"{e}"
         )
         return
-    tags = sorted(item.itunes_keywords.keywords) if item.itunes_keywords else parse_tags(item.link, episode_number,show,show_details)
+    tags = sorted(item.itunes_keywords.keywords) if item.itunes_keywords else parse_tags(item.link, episode_number,show,show_details) if item.link else []
 
     episode_links = get_links(item.content_encoded if item.content_encoded else item.description)
 


### PR DESCRIPTION
First pass of getting TWiB to scrape now that it is being hosted on Fountain. This was solely meant to explore what might need to change, not be a real attempt at a long term change.

Some items we have been using are missing at the moment. Some are not a big deal, others may require more work.
- no copyright
- no per-episode <link>
- no <podcast:episode>. right now they don't seem to have this concept. Quick work around would be to inject numbers into the show titles, but that comes with the obvious downsides. This has been raised to fountain.

And then additionally, the pubDate format uses "GMT" rather than a numeric timezone offset. Numeric one's seem to be preferred by the standard(s), but this is allowed so we should probably support it. 

My janky workarounds:
- Make copyright optional
- Make fireside_url optional in output model
- Use a random episode number
- Skip processing of tags and sponsors if we don't have a link
- Handle non-numeric timezone offset.
